### PR TITLE
Update dockerInstallation.mdx

### DIFF
--- a/docs/getting-started/dockerInstallation.mdx
+++ b/docs/getting-started/dockerInstallation.mdx
@@ -67,7 +67,9 @@ First of all you need to download leemons on your computer or sever, don't worry
   <summary>Or see the code</summary>
   <CodeBlock language="bash" title="leemons.sh" showLineNumbers >{leemonsInstallBash}</CodeBlock>
   </details>
-
+  ::::tip For Apple Chip you must need add this line  
+  `platform: linux/x86_64` in line 25 up at the line of `image:mysql5.7` at the same identation of this
+    :::
   Now you only need to run the file, this can differ based on your operating system:
 
   1. Firstly, you need to open the terminal.


### PR DESCRIPTION
This message appear during the docker installation on macOS in Apple Chip (M1):  ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries

Solution, describe the platform on the leemons.sh before the first run, adding this line platform: linux/x86_64 before the line wich describe the image o mysql.

Work on iMac 24" chip M1